### PR TITLE
Upgrade argonaut dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "purescript-maybe": "^4.0.0",
     "purescript-generics-rep": "^6.1.0",
     "purescript-foreign-object": "^2.0.0",
-    "purescript-argonaut-codecs": "^6.0.0",
+    "purescript-argonaut-codecs": "^7.0.0",
     "purescript-either": "^4.1.0",
     "purescript-foldable-traversable": "^4.1.0",
     "purescript-newtype": "^3.0.0",

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,9 +2,8 @@ module Test.Main where
 
 import Prelude
 
-import Data.Argonaut.Decode (class DecodeJson, decodeJson)
+import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError, decodeJson, parseJson)
 import Data.Argonaut.Encode (encodeJson)
-import Data.Argonaut.Parser (jsonParser)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
@@ -262,5 +261,5 @@ main = runTest do
             expected = Right packageMeta2
         Assert.equal expected actual
 
-parseDecode :: forall a. DecodeJson a => String -> Either String a
-parseDecode = decodeJson <=< jsonParser
+parseDecode :: forall a. DecodeJson a => String -> Either JsonDecodeError a
+parseDecode = decodeJson <=< parseJson


### PR DESCRIPTION
The most recent [major release of the Argonaut library](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0) introduces typed errors. This PR updates this library for compatibility.

This library will need a new release to stay compatible with the next package set, as tracked by this issue:
https://github.com/purescript/package-sets/issues/642

Sorry for the hassle! Thanks!